### PR TITLE
Passing Template between ViewModels

### DIFF
--- a/Diplomatic/ViewModels/SignaturePickerViewModel.cs
+++ b/Diplomatic/ViewModels/SignaturePickerViewModel.cs
@@ -1,16 +1,17 @@
 ﻿using System;
 using Xamarin.Forms;
-
+using Diplomatic.Core;
 namespace Diplomatic.ViewModels
 {
     public class SignaturePickerViewModel
     {
         // List of signature items to be displayed.
         public ImageCell[] SignatureItems { get; set; }
-        
-        public SignaturePickerViewModel()
-        {
+        public Template SelectedTemplate { get; set; }
 
+        public SignaturePickerViewModel(Template selectedTemplate)
+        {
+            SelectedTemplate = selectedTemplate;
             SignatureItems = new ImageCell[]
             {
                 // Creating a few signatures for testing purposes

--- a/Diplomatic/Views/Signatures.xaml
+++ b/Diplomatic/Views/Signatures.xaml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:local="clr-namespace:Diplomatic.ViewModels" x:Class="Diplomatic.Views.Signatures" Title="Signatures">
-    <ContentPage.BindingContext>
-        <local:SignaturePickerViewModel />
-    </ContentPage.BindingContext>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+             xmlns:local="clr-namespace:Diplomatic.ViewModels" 
+             x:Class="Diplomatic.Views.Signatures" Title="Signatures">
     <ContentPage.Content>
         <ScrollView>
             <StackLayout Padding="20,0,20,0" BackgroundColor="{StaticResource backgroundColor}">
@@ -34,6 +34,7 @@
                 <!-- Button to continue
                 Clicked="NextPage"
                 -->
+                <Label Text="{Binding SelectedTemplate.TemplateName}" />
                 <Button Text="Next" Style="{StaticResource nextPageButton}" />
             </StackLayout>
         </ScrollView>

--- a/Diplomatic/Views/Signatures.xaml.cs
+++ b/Diplomatic/Views/Signatures.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-
 using Xamarin.Forms;
 
 namespace Diplomatic.Views

--- a/Diplomatic/Views/TextFields.xaml.cs
+++ b/Diplomatic/Views/TextFields.xaml.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-
 using Xamarin.Forms;
-
+using Diplomatic.ViewModels;
+using Diplomatic.Core;
 namespace Diplomatic.Views
 {
     public partial class TextFields : ContentPage
@@ -14,6 +14,8 @@ namespace Diplomatic.Views
         async void NextPage(object sender, EventArgs e)
         {
             var next = new Signatures();
+
+            next.BindingContext = new SignaturePickerViewModel(((TextFieldViewModel)BindingContext).SelectedTemplate);
             // We do not need to submit any info to the page here yet
             await Navigation.PushAsync(next);
         }


### PR DESCRIPTION
To suit our design of how information should be stored in the process of customizing the template
we need to pass the selected template object between viewmodels. This pull request sets up the passing of the template object from the text-field view to the signature view(model). 
## Changes :balloon:

Describe the big picture of your changes here. If it fixes a bug (:bug:) or resolves a feature request, refer to it here.

## Types of changes

What types of changes does your code introduce? _Mark boxes that apply with an `x`._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist :heavy_check_mark:

_Mark boxes that apply with an `x`. These can also be filled out after the pull request is created._

- [ ] I have read the coding convention [guidelines](https://github.com/Dualog-students/dualog-students.github.io#company-guidelines) and my code follows these.
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a large or complex change, start the discussion by explaining why you chose to implement your solution the way you did, what alternatives you considered, etc.

<!-- The structure of your pull request can be altered if the template does not suit your needs -->
