### PR TITLE
Cosmetic/working with triggers

### DIFF
--- a/Diplomatic.Android/Resources/drawable/splash_screen.xml
+++ b/Diplomatic.Android/Resources/drawable/splash_screen.xml
@@ -10,3 +10,5 @@
         android:gravity="center"/>
   </item>
 </layer-list>
+
+<!---->

--- a/Diplomatic.iOS/Diplomatic.iOS.csproj
+++ b/Diplomatic.iOS/Diplomatic.iOS.csproj
@@ -145,18 +145,42 @@
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
       <Visible>false</Visible>
     </ImageAsset>
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-48.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-55.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-88.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-172.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-196.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-16.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-32.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-64.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-128.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-256.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-512.png" />
-    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-48.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-55.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-88.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-172.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-196.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-16.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-32.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-64.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-128.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-256.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Icon-512.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Diplomatic/App.xaml
+++ b/Diplomatic/App.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Application xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Diplomatic.Utils.Triggers"
              x:Class="Diplomatic.App">
 	<Application.Resources>
         <Color x:Key="backgroundColor">#e5f4f2</Color>
@@ -13,6 +14,31 @@
             <Setter Property="TextColor" Value="White"/>
             <Setter Property="FontSize" Value="Small"/>
             <Setter Property="WidthRequest" Value="75" />
+        </Style>
+
+        <Style TargetType="Label">
+            <Setter Property="Opacity" Value="0.5"/>
+            <Style.Triggers>
+                <Trigger TargetType="Label"
+                         Property="IsVisible" Value="True">
+                    <Trigger.EnterActions>
+                        <local:OpacityTriggerAction StartsFrom="0"/>
+                    </Trigger.EnterActions>
+                    <Trigger.ExitActions>
+                        <local:OpacityTriggerAction StartsFrom="1"/>
+                    </Trigger.ExitActions>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+
+        <Style TargetType="Entry">
+            <Setter Property="Opacity" Value="0.75"/>
+            <Style.Triggers>
+                <Trigger TargetType="Entry"
+                         Property="IsFocused" Value="True">
+                    <Setter Property="Opacity" Value="1"/>
+                </Trigger>
+            </Style.Triggers>
         </Style>
 
         <OnPlatform

--- a/Diplomatic/App.xaml
+++ b/Diplomatic/App.xaml
@@ -17,16 +17,13 @@
         </Style>
 
         <Style TargetType="Label">
-            <Setter Property="Opacity" Value="0.5"/>
+            <Setter Property="Opacity" Value="1"/>
             <Style.Triggers>
                 <Trigger TargetType="Label"
                          Property="IsVisible" Value="True">
                     <Trigger.EnterActions>
                         <local:OpacityTriggerAction StartsFrom="0"/>
                     </Trigger.EnterActions>
-                    <Trigger.ExitActions>
-                        <local:OpacityTriggerAction StartsFrom="1"/>
-                    </Trigger.ExitActions>
                 </Trigger>
             </Style.Triggers>
         </Style>

--- a/Diplomatic/Utils/Behaviors/FormatValidator.cs
+++ b/Diplomatic/Utils/Behaviors/FormatValidator.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using Xamarin.Forms;
 
 namespace Diplomatic.Utils.Behaviors
@@ -20,9 +20,9 @@ namespace Diplomatic.Utils.Behaviors
 
         public void ValidateFormat(object sender, TextChangedEventArgs args)
         {
-            string text = (sender as Entry).Text;
-            var regex = new Regex(Pattern, RegexOptions.Compiled);
-            (sender as Entry).TextColor = regex.IsMatch(text) ? Color.Default : Color.Red;
+            var entry = (Entry)sender;
+            string text = entry.Text;
+            entry.TextColor = Regex.IsMatch(text, Pattern) ? Color.Default : Color.Red;
         }
     }
 }

--- a/Diplomatic/Utils/Triggers/OpacityAnimation.cs
+++ b/Diplomatic/Utils/Triggers/OpacityAnimation.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms;
+
+namespace Diplomatic.Utils.Triggers
+{
+    public class OpacityTriggerAction : TriggerAction<VisualElement>
+    {
+        public int StartsFrom { set; get; } = 0;
+        //public double Opacity { get; set; } = 1;
+        //public uint Duration { get; set; } = 10000;
+
+        protected override void Invoke(VisualElement visual)
+        {
+            visual.Animate("label", new Animation((d) => {
+                var val = StartsFrom == 0 ? d : 1 - d;
+                visual.Opacity = val;
+
+            }),
+            length: 500, // milliseconds
+            easing: Easing.Linear);
+        }
+    }
+}

--- a/Diplomatic/Utils/Triggers/OpacityAnimation.cs
+++ b/Diplomatic/Utils/Triggers/OpacityAnimation.cs
@@ -8,8 +8,6 @@ namespace Diplomatic.Utils.Triggers
     public class OpacityTriggerAction : TriggerAction<VisualElement>
     {
         public int StartsFrom { set; get; } = 0;
-        //public double Opacity { get; set; } = 1;
-        //public uint Duration { get; set; } = 10000;
 
         protected override void Invoke(VisualElement visual)
         {
@@ -18,7 +16,7 @@ namespace Diplomatic.Utils.Triggers
                 visual.Opacity = val;
 
             }),
-            length: 500, // milliseconds
+            length: 500,
             easing: Easing.Linear);
         }
     }

--- a/Diplomatic/Utils/Triggers/ScaleAnimation.cs
+++ b/Diplomatic/Utils/Triggers/ScaleAnimation.cs
@@ -1,4 +1,4 @@
-﻿using Xamarin.Forms;
+using Xamarin.Forms;
 
 namespace Diplomatic.Utils.Triggers
 {


### PR DESCRIPTION
## Changes :balloon:

Added triggers to labels and entry fields. The labels at main page is now faded in to full opacity once they are displayed (by clicking the image).

The entry fields are now at 75% opacity, once they are in focus, they will display at 100% opacity. 

## Types of changes

What types of changes does your code introduce? _Mark boxes that apply with an `x`._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist :heavy_check_mark:

_Mark boxes that apply with an `x`. These can also be filled out after the pull request is created._

- [ ] I have read the coding convention [guidelines](https://github.com/Dualog-students/dualog-students.github.io#company-guidelines) and my code follows these.
- [ ] Unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- The structure of your pull request can be altered if the template does not suit your needs -->
